### PR TITLE
Update Xournal++ to 1.2.5 and make arguments easer to read

### DIFF
--- a/xournal++/tools/chocolateyinstall.ps1
+++ b/xournal++/tools/chocolateyinstall.ps1
@@ -6,19 +6,14 @@ $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $packageArgs = @{
   packageName  = $packageName
   unzipLocation = $toolsDir
-  url          = 'https://github.com/xournalpp/xournalpp/releases/download/v1.2.3/xournalpp-1.2.3-windows.zip'
-  checksum     = 'dcb67d17489b84ebd95db6e20b379b95ea8b62cbdb3001ba40b4913816c6fd1c'
+  url          = 'https://github.com/xournalpp/xournalpp/releases/download/v1.2.5/xournalpp-1.2.5-windows-setup-x86_64.exe'
+  checksum     = '386FFE9CE5A6D8D6CF693FE0CA179248C307FC748F02C195C86F844CFA45F567'
   checksumType = 'sha256'
+  FileType     = 'exe'
+  silentArgs   = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- /S /quiet'
 }
-
-Install-ChocolateyZipPackage @packageArgs
-
 $ErrorActionPreference = 'Stop'
 
-$fileType = 'exe'
-$silentArgs = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- /S /quiet'
-
-$file = $toolsDir+'\xournalpp-1.2.3-windows.exe'
 
  
-Install-ChocolateyPackage "$packageName" -FileType "$fileType" -SilentArgs "$silentArgs" -File "$file" -Checksum "$checksum" -ChecksumType "$checksumType"
+Install-ChocolateyPackage @packageArgs

--- a/xournal++/xournal++.nuspec
+++ b/xournal++/xournal++.nuspec
@@ -5,7 +5,7 @@
     <!-- Read this before publishing packages to chocolatey.org: https://github.com/chocolatey/chocolatey/wiki/CreatePackages -->
     <id>xournalplusplus</id>
     <title>xournal++</title>
-    <version>1.2.3</version>
+    <version>1.2.5</version>
     <authors>xournalpp</authors>
     <owners>dp3atksu</owners>
     <summary>  Xournal++ is a handwriting notetaking software with PDF annotation support. Written in C++ with GTK3, supporting Linux (e.g. Ubuntu, Debian, Arch, SUSE), macOS and Windows 10. Supports pen input from devices such as Wacom Tablets </summary>


### PR DESCRIPTION
Version 1.2.5 was released in December 2024. I went ahead and updated the repo so that it should be easy to push to Chocolatey.